### PR TITLE
Add back pthread_attr_setstacksize update

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -398,7 +398,6 @@ static void * prvTimerTickHandler( void * arg )
         }
 
         usleep( portTICK_RATE_MICROSECONDS );
-        pthread_testcancel();
     }
 
     return NULL;

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -255,6 +255,7 @@ BaseType_t xPortStartScheduler( void )
         Thread_t * pxThread = ( Thread_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
 
         pthread_cancel( pxThread->pthread );
+        event_signal( pxThread->pthread );
         pthread_join( pxThread->pthread, NULL );
         event_delete( pxThread->ev );
     }
@@ -483,6 +484,7 @@ void vPortCancelThread( void * pxTaskToDelete )
      * The thread has already been suspended so it can be safely cancelled.
      */
     pthread_cancel( pxThreadToCancel->pthread );
+    event_signal( pxThreadToCancel->ev );
     pthread_join( pxThreadToCancel->pthread, NULL );
     event_delete( pxThreadToCancel->ev );
 }

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -169,15 +169,13 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     thread->pvParams = pvParameters;
     thread->xDying = pdFALSE;
 
-    /* Ensure ulStackSize is at least PTHREAD_STACK_MIN */
-    ulStackSize = ( ulStackSize < PTHREAD_STACK_MIN ) ? PTHREAD_STACK_MIN : ulStackSize;
-
     pthread_attr_init( &xThreadAttributes );
-    iRet = pthread_attr_setstacksize( &xThreadAttributes, ulStackSize );
+    iRet = pthread_attr_setstack( &xThreadAttributes, pxEndOfStack, ulStackSize );
 
     if( iRet != 0 )
     {
-        fprintf( stderr, "[WARN] pthread_attr_setstacksize failed with return value: %d. Default stack size will be used.\n", iRet );
+        fprintf( stderr, "[WARN] pthread_attr_setstack failed with return value: %d. Default stack will be used.\n", iRet );
+        fprintf( stderr, "[WARN] Increase the stack size to PTHREAD_STACK_MIN.\n" );
     }
 
     thread->ev = event_create();

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -106,7 +106,7 @@ static volatile BaseType_t uxCriticalNesting;
 static BaseType_t xSchedulerEnd = pdFALSE;
 static pthread_t hTimerTickThread;
 static uint64_t prvStartTimeNs;
-static List_t xThreadList;             /* The list to track all the pthreads which are not deleted. */
+static List_t xThreadList; /* The list to track all the pthreads which are not deleted. */
 /*-----------------------------------------------------------*/
 
 static void prvSetupSignalsAndSchedulerPolicy( void );
@@ -250,7 +250,7 @@ BaseType_t xPortStartScheduler( void )
 
     for( pxIterator = listGET_HEAD_ENTRY( &xThreadList ); pxIterator != pxEndMarker; pxIterator = listGET_NEXT( pxIterator ) )
     {
-        Thread_t *pxThread = ( Thread_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
+        Thread_t * pxThread = ( Thread_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
 
         pthread_cancel( pxThread->pthread );
         pthread_join( pxThread->pthread, NULL );
@@ -377,9 +377,9 @@ static uint64_t prvGetTimeNs( void )
  * to adjust timing according to full demo requirements */
 /* static uint64_t prvTickCount; */
 
-static void* prvTimerTickHandler(void *arg)
+static void * prvTimerTickHandler( void * arg )
 {
-    for(;;)
+    for( ; ; )
     {
         /*
          * signal to the active task to cause tick handling or
@@ -389,13 +389,15 @@ static void* prvTimerTickHandler(void *arg)
         Thread_t * thread;
 
         hCurrentTask = xTaskGetCurrentTaskHandle();
+
         if( hCurrentTask != NULL )
         {
             thread = prvGetThreadFromTask( hCurrentTask );
             pthread_kill( thread->pthread, SIGALRM );
         }
+
         usleep( portTICK_RATE_MICROSECONDS );
-	pthread_testcancel();
+        pthread_testcancel();
     }
 }
 

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -255,7 +255,7 @@ BaseType_t xPortStartScheduler( void )
         Thread_t * pxThread = ( Thread_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
 
         pthread_cancel( pxThread->pthread );
-        event_signal( pxThread->pthread );
+        event_signal( pxThread->ev );
         pthread_join( pxThread->pthread, NULL );
         event_delete( pxThread->ev );
     }
@@ -387,17 +387,8 @@ static void * prvTimerTickHandler( void * arg )
          * signal to the active task to cause tick handling or
          * preemption (if enabled)
          */
-        TaskHandle_t hCurrentTask;
-        Thread_t * thread;
-
-        hCurrentTask = xTaskGetCurrentTaskHandle();
-
-        if( hCurrentTask != NULL )
-        {
-            thread = prvGetThreadFromTask( hCurrentTask );
-            pthread_kill( thread->pthread, SIGALRM );
-        }
-
+        Thread_t * thread = prvGetThreadFromTask( xTaskGetCurrentTaskHandle() );
+        pthread_kill( thread->pthread, SIGALRM );
         usleep( portTICK_RATE_MICROSECONDS );
     }
 

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -60,6 +60,7 @@
 #include <sys/time.h>
 #include <sys/times.h>
 #include <time.h>
+#include <unistd.h>
 
 #ifdef __APPLE__
     #include <mach/mach_vm.h>


### PR DESCRIPTION
Add back pthread_attr_setstacksize update

Description
-----------
In this PR
* Add back `pthread_attr_setstacksize` change
* Stop the timer in `vPortEndScheduler`
* Move list insert and remove function call to a critical section
* Create cancellation point in prvSuspendSelf function

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
